### PR TITLE
Make Role Claim configurable; Handle Role Claims formated as Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following configuration options are available for this plugin:
 | ---- | ------------- | ------ | ----------- |
 | openIDAllowedTokenIssuers | Empty Set | Comma delimited set of URIs | The allowed issuers to trust from the JWT. The `iss` claim must be contained in this set. See [Issuers](#Issuers). |
 | openIDAllowedAudience | `null` | String | If not set, defaults to `null`, and the `aud` claim is not checked. If set, the JWT must have the configured `aud` in its claims. If it is missing, the token will be rejected. |
+| openIDRoleClaim | `sub` | String | The JWT claim used to get the authenticated token's role. Defaults to the `sub` claim, but can be any claim. |
 | openIDAcceptedTimeLeewaySeconds | `0` | Number (no decimals) | The number of seconds that a token will be accepted past its expiration time. |
 | openIDJwkCacheSize | `10` | Number (no decimals) | The number of JWK values to keep in the cache. |
 | openIDJwkExpiresSeconds | `300` | Number (no decimals) | The length of time, in seconds, to store a JWK before calling the issuer again. Note that this time is also the maximum time that a revoked token can be used. A longer window may improve performance, but it also increases the length of time than a deactivated token could be used. |
@@ -38,6 +39,12 @@ Note that the only required configuration is the `openIDAllowedTokenIssuers`.
 ### Supported Algorithms
 Here is a list of supported algorithms for the OpenID Connect auth plugin: RS256, RS384, RS512, ES256, ES384, ES512.
 The algorithm names follow the spec in [RFC-7518](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1).
+
+### Role Claim
+The JWT claim used to retrieve the role is `sub`, by default. If required, you can change the claim by configuring the
+`openIDRoleClaim`. Note that this library can handle roles that are a String (JSON text) or Arrays of strings. In the
+case that the JSON node is an Array, this library retrieves the first element of the array for the role. This could lead
+to undefined behavior if the array changes order, so it is recommended to use single element arrays.
 
 ### Keycloak
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The algorithm names follow the spec in [RFC-7518](https://datatracker.ietf.org/d
 
 ### Role Claim
 The JWT claim used to retrieve the role is `sub`, by default. If required, you can change the claim by configuring the
-`openIDRoleClaim`. Note that this library can handle roles that are a String (JSON text) or Arrays of strings. In the
+`openIDRoleClaim`. Note that this library can handle roles that are a String (JSON text) or Arrays of Strings. In the
 case that the JSON node is an Array, this library retrieves the first element of the array for the role. This could lead
 to undefined behavior if the array changes order, so it is recommended to use single element arrays.
 

--- a/src/main/java/com/datastax/oss/pulsar/auth/ConfigUtils.java
+++ b/src/main/java/com/datastax/oss/pulsar/auth/ConfigUtils.java
@@ -28,10 +28,26 @@ public class ConfigUtils {
      * Get configured property as a string. If not configured, return null.
      * @param conf - the configuration map
      * @param configProp - the property to get
-     * @return a string from the conf
+     * @return a string from the conf or null, if the configuration property was not set
      */
     public static String getConfigValueAsString(ServiceConfiguration conf, String configProp) throws IllegalArgumentException {
         String value = getConfigValueAsStringImpl(conf, configProp);
+        log.info("Configuration for [{}] is [{}]", configProp, value);
+        return value;
+    }
+
+    /**
+     * Get configured property as a string. If not configured, return null.
+     * @param conf - the configuration map
+     * @param configProp - the property to get
+     * @param defaultValue - the value to use if the configuration value is not set
+     * @return a string from the conf or the default value
+     */
+    public static String getConfigValueAsString(ServiceConfiguration conf, String configProp, String defaultValue) throws IllegalArgumentException {
+        String value = getConfigValueAsStringImpl(conf, configProp);
+        if (value == null) {
+            value = defaultValue;
+        }
         log.info("Configuration for [{}] is [{}]", configProp, value);
         return value;
     }

--- a/src/test/java/com/datastax/oss/pulsar/auth/AuthenticationProviderOpenIDTest.java
+++ b/src/test/java/com/datastax/oss/pulsar/auth/AuthenticationProviderOpenIDTest.java
@@ -200,7 +200,7 @@ public class AuthenticationProviderOpenIDTest {
         defaultJwtBuilder.setAudience("audience");
         DecodedJWT jwtWithoutSub = JWT.decode(defaultJwtBuilder.compact());
 
-        // An empty JWT must result in a null role
+        // A JWT with an empty role claim must result in a null role
         Assertions.assertNull(provider.getRole(jwtWithoutSub));
     }
 
@@ -219,7 +219,6 @@ public class AuthenticationProviderOpenIDTest {
         defaultJwtBuilder.setSubject("my-role");
         DecodedJWT jwt = JWT.decode(defaultJwtBuilder.compact());
 
-        // An empty JWT must result in a null role
         Assertions.assertEquals("my-role", provider.getRole(jwt));
     }
 
@@ -240,7 +239,6 @@ public class AuthenticationProviderOpenIDTest {
         defaultJwtBuilder.setClaims(claims);
         DecodedJWT jwt = JWT.decode(defaultJwtBuilder.compact());
 
-        // An empty JWT must result in a null role
         Assertions.assertEquals("my-role", provider.getRole(jwt));
     }
 
@@ -261,7 +259,6 @@ public class AuthenticationProviderOpenIDTest {
         defaultJwtBuilder.setClaims(claims);
         DecodedJWT jwt = JWT.decode(defaultJwtBuilder.compact());
 
-        // An empty JWT must result in a null role
         Assertions.assertEquals("my-role-1", provider.getRole(jwt));
     }
 
@@ -282,7 +279,7 @@ public class AuthenticationProviderOpenIDTest {
         defaultJwtBuilder.setClaims(claims);
         DecodedJWT jwt = JWT.decode(defaultJwtBuilder.compact());
 
-        // An empty JWT must result in a null role
+        // A JWT with an empty list role claim must result in a null role
         Assertions.assertNull(provider.getRole(jwt));
     }
 }

--- a/src/test/java/com/datastax/oss/pulsar/auth/ConfigUtilsTest.java
+++ b/src/test/java/com/datastax/oss/pulsar/auth/ConfigUtilsTest.java
@@ -43,6 +43,25 @@ public class ConfigUtilsTest {
     }
 
     @Test
+    public void testGetConfigValueAsStringWithDefaultWorks() {
+        Properties props = new Properties();
+        props.setProperty("prop1", "audience");
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setProperties(props);
+        String actual = ConfigUtils.getConfigValueAsString(config, "prop1", "default");
+        Assertions.assertEquals("audience", actual);
+    }
+
+    @Test
+    public void testGetConfigValueAsStringReturnsDefaultIfMissing() {
+        Properties props = new Properties();
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setProperties(props);
+        String actual = ConfigUtils.getConfigValueAsString(config, "prop1", "default");
+        Assertions.assertEquals("default", actual);
+    }
+
+    @Test
     public void testGetConfigValueAsSetReturnsWorks() {
         Properties props = new Properties();
         props.setProperty("prop1", "a, b,   c");


### PR DESCRIPTION
In order to support Azure AD, we need to let end users configure which claim should be used for the `role`. Further, that claim might be formatted as a list, so we need to handle that gracefully. This PR addresses both requirements and adds tests to cover all new additions.