### PR TITLE
deps: Update dependency to fix CVE-2024-36114 & CVE-2024-7254

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
         <pulsar.version>2.10.0</pulsar.version>
         <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
         <jupiter.version>5.7.2</jupiter.version>
+        <aircompressor.version>0.27</aircompressor.version>
+        <protobuf.version>3.25.5</protobuf.version>
     </properties>
     <build>
             <plugins>
@@ -141,6 +143,10 @@ limitations under the License.]]></inlineHeader>
                     <groupId>io.grpc</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java-util</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -161,6 +167,16 @@ limitations under the License.]]></inlineHeader>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${jupiter.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>aircompressor</artifactId>
+            <version>${aircompressor.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,15 +168,19 @@ limitations under the License.]]></inlineHeader>
             <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Override transitive dependency version to fix vulnerability -->
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>aircompressor</artifactId>
             <version>${aircompressor.version}</version>
+            <scope>runtime</scope>
         </dependency>
+        <!-- Override transitive dependency version to fix vulnerability -->
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${protobuf.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,10 +143,6 @@ limitations under the License.]]></inlineHeader>
                     <groupId>io.grpc</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java-util</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
aircompressor 0.21 contains CVE-2024-36114 vulnerability and its fixed in 0.27
protobuf-java 3.19.6 contains CVE-2024-7254 vulnerability and its fixed in contains 3.25.5
